### PR TITLE
release v1.0.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
   - Once a match was made, the search state was cleared entirely, resulting in fewer matches.
   - In HybridBigramInvertedIndex, the edit distance was not calculated correctly. 
 - Typo in README is fixed.
+- Typo of search class is fixed. Not HyblidBigramInvertedIndex, but HybridBigramInvertedIndex.
 
 ## [1.0.3] - 2024-12-28
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,14 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [1.0.4] - 2025-01-07
+### Fixed
+- fuzzy search bug is fixed.
+  - The bitap algorithm did not correctly calculate the single-character deletion status.
+  - Once a match was made, the search state was cleared entirely, resulting in fewer matches.
+  - In HybridBigramInvertedIndex, the edit distance was not calculated correctly. 
+- Typo in README is fixed.
+
 ## [1.0.3] - 2024-12-28
 ### Fixed
 - update README.
@@ -28,6 +36,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - search frontend, google-like syntax
 - sorting search result based on TF-IDF
 
-[Unreleased]: https://github.com/osawa-naotaka/unisearch/compare/v1.0.3...HEAD
+[Unreleased]: https://github.com/osawa-naotaka/unisearch/compare/v1.0.4...HEAD
+[1.0.4]: https://github.com/osawa-naotaka/unisearch/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/osawa-naotaka/unisearch/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/osawa-naotaka/unisearch/compare/v1.0.0...v1.0.2

--- a/README.en.md
+++ b/README.en.md
@@ -197,12 +197,12 @@ Full-text search based on the LinearIndex described above will provide sufficien
 However, if a faster search is needed, a different index format can be used to speed up the search.
 
 ```
-import { HyblidBigramInvertedIndex, createIndex, search, UniSearchError } from "unisearch.js";
+import { HybridBigramInvertedIndex, createIndex, search, UniSearchError } from "unisearch.js";
 
-const index = createIndex(HyblidBigramInvertedIndex, array_of_articles);
+const index = createIndex(HybridBigramInvertedIndex, array_of_articles);
 ```
 
-Using HyblidBigramInvertedIndex improves the search speed by a factor of approximately 10. The usage of the search is exactly the same as with LinearIndex.
+Using HybridBigramInvertedIndex improves the search speed by a factor of approximately 10. The usage of the search is exactly the same as with LinearIndex.
 
 However, in exchange for the improved search speed, there are a number of drawbacks
 
@@ -212,7 +212,7 @@ However, in exchange for the improved search speed, there are a number of drawba
 4. Some of the information in the search results will be missing: pos and wordaround will not exist.
 5. Scoring based on TF-IDF is incomplete. Only simple TFs are calculated now.
 
-Overall, HyblidBigramInvertedIndex is not really worth using. Consider using it only if you really need a fast search.
+Overall, HybridBigramInvertedIndex is not really worth using. Consider using it only if you really need a fast search.
 
 ## Introduction of search algorithm
 
@@ -222,16 +222,16 @@ When using LinearIndex, the exact match search algorithm is very simple. Or rath
 
 The fuzzy search uses the bitap algorithm, which is 50-100 times slower than indexOf. I tried to realize bitap in Rust-WASM, but the speed was not much different from that of JavaScript, so I did not adopt it. The characters to be searched are segmented into grapheme units using Intl.Segmenter(). Therefore, edit distances can be calculated correctly even for characters consisting of multiple code points, such as Kanji variants, pictographs, national flags, and so on. However, the memory usage is doubled because the index of each grapheme unit is generated separately from the index of an ordinary string.
 
-### HyblidBigramInvertedIndex
+### HybridBigramInvertedIndex
 
-HyblidBigramInvertedIndex classifies characters into two categories, one for languages such as Japanese, where words are difficult to separate, and the other for languages such as English, where words can be separated by spaces, and generates different indexes for each. For English, an ordinary word-by-word inverted index was created, while for Japanese and other languages, an inverted index was created by fragmenting sentences using Bigram without separating words.
+HybridBigramInvertedIndex classifies characters into two categories, one for languages such as Japanese, where words are difficult to separate, and the other for languages such as English, where words can be separated by spaces, and generates different indexes for each. For English, an ordinary word-by-word inverted index was created, while for Japanese and other languages, an inverted index was created by fragmenting sentences using Bigram without separating words.
 Although increasing the number of ngrams (e.g., Trigram) can reduce search noise, it increases the size of the index, so Bigram was used to consider a balance.
 
 ### Preprocessing
 
 Preprocessing is simple: Unicode normalization (NFKC), lowercasing of alphabetic and other characters, and some normalization of Japanese. Stopwords and stemming are not used for inverted indexes, such as English. Since we aimed to be language-neutral, we did not include too many special processes, but aimed to achieve a range of search capabilities.
 
-In addition to the above, HyblidBigramInvertedIndex removes symbols and signs and uses them as delimiters, divides by whitespace, and divides by character type (classifying languages that cannot be tokenized, such as Japanese, and those that can). Therefore, symbols by themselves cannot be searched, and URLs are also tokenized. It would be nice if there was a mechanism that could be shared across all languages, but it seems to be incomplete. Intl.Segmenter() can be used for Japanese and Chinese, so we are looking forward to the future.
+In addition to the above, HybridBigramInvertedIndex removes symbols and signs and uses them as delimiters, divides by whitespace, and divides by character type (classifying languages that cannot be tokenized, such as Japanese, and those that can). Therefore, symbols by themselves cannot be searched, and URLs are also tokenized. It would be nice if there was a mechanism that could be shared across all languages, but it seems to be incomplete. Intl.Segmenter() can be used for Japanese and Chinese, so we are looking forward to the future.
 
 ### Other algorithms to consider
 

--- a/README.md
+++ b/README.md
@@ -200,12 +200,12 @@ tokenにはクエリ中の個々の検索文字列が設定されます。path�
 しかし、もしもっと高速な検索を必要とする場合、違うインデックス形式を使うことにより、検索の高速化が達成できます。
 
 ```
-import { HyblidBigramInvertedIndex, createIndex, search, UniSearchError } from "unisearch.js";
+import { HybridBigramInvertedIndex, createIndex, search, UniSearchError } from "unisearch.js";
 
-const index = createIndex(HyblidBigramInvertedIndex, array_of_articles);
+const index = createIndex(HybridBigramInvertedIndex, array_of_articles);
 ```
 
-HyblidBigramInvertedIndexを使うことにより、おおよそ10倍の検索速度向上がみられます。検索の使い方はLinearIndex時と全く同一です。
+HybridBigramInvertedIndexを使うことにより、おおよそ10倍の検索速度向上がみられます。検索の使い方はLinearIndex時と全く同一です。
 
 ただし、検索の速度向上のかわり、多数の欠点も存在します。
 
@@ -215,7 +215,7 @@ HyblidBigramInvertedIndexを使うことにより、おおよそ10倍の検索�
 4. 検索結果の情報の一部が欠けます。posとwordaroundが存在しなくなります。
 5. TF-IDFに基づくスコアリングが未完成です。今は単純なTFのみ計算しています。
 
-総合的に見て、HyblidBigramInvertedIndexを使う価値はあまりありません。どうしても高速な検索が必要な場合のみ利用を検討してください。
+総合的に見て、HybridBigramInvertedIndexを使う価値はあまりありません。どうしても高速な検索が必要な場合のみ利用を検討してください。
 
 ## 検索アルゴリズムの紹介
 
@@ -225,16 +225,16 @@ LinearIndexを使う場合、完全一致検索アルゴリズムは非常に単
 
 あいまい検索は、教科書通りのbitapアルゴリズムを用いています。indexOfに比べ50-100倍程度遅い速度です。Rust-WASMでbitapを実現してみましたが、JavaScriptで実現した場合に比べても大差ない速度のため、採用を見送りました。検索対象の文字はIntl.Segmenter()を使ってグラフェム単位に分割しています。そのため、漢字の異字体や絵文字、国旗などなど、複数のコードポイントからなる文字についても、正しく編集距離を計算できます。ただし、グラフェム単位のインデックスを普通の文字列のインデックスと別に生成するため、メモリ使用量が倍になっています。
 
-### HyblidBigramInvertedIndex
+### HybridBigramInvertedIndex
 
-HyblidBigramInvertedIndexは、日本語のような、単語の分かち書きが難しい言語と、英語のような、空白で単語が区切れる言語、それぞれに文字を分類して、違うインデックスを生成することで検索を実現しています。英語は普通の単語単位の転置インデックスを作り、日本語などは分かち書きせずBigramで文章を断片化して転置インデックスを生成しました。
+HybridBigramInvertedIndexは、日本語のような、単語の分かち書きが難しい言語と、英語のような、空白で単語が区切れる言語、それぞれに文字を分類して、違うインデックスを生成することで検索を実現しています。英語は普通の単語単位の転置インデックスを作り、日本語などは分かち書きせずBigramで文章を断片化して転置インデックスを生成しました。
 Trigramなど、Ngramを増やすことで検索ノイズは軽減できるのですが、その代わりインデックスサイズが大きくなってしまうため、バランスをみてBigramを採用しました。
 
 ### 前処理
 
 前処理は単純です。Unicodeの正規化(NFKC)や英文字などの小文字化、日本語の一部の正規化をしている程度です。転置インデックスの英語などにおいてもストップワードやステミングは採用していません。言語中立を目指したため、あまり特殊な処理は入れずに検索できる範囲の能力を目指しました。
 
-HyblidBigramInvertedIndexでは、上記に加え、約物・記号の削除とそれらをデリミタとした分割、空白による分割、文字種（日本語のようにトークナイズできない言語とできる言語を分類）による分割を行っています。そのため、記号単体では検索できず、URLもトークナイズされます。全言語に共通で分かち書きできる機構があれば良いのですが、未だ未完の状態のようです。一応、Intl.Segmenter()は日本語と中国語の分かち書きができるらしいので、今後に期待します。
+HybridBigramInvertedIndexでは、上記に加え、約物・記号の削除とそれらをデリミタとした分割、空白による分割、文字種（日本語のようにトークナイズできない言語とできる言語を分類）による分割を行っています。そのため、記号単体では検索できず、URLもトークナイズされます。全言語に共通で分かち書きできる機構があれば良いのですが、未だ未完の状態のようです。一応、Intl.Segmenter()は日本語と中国語の分かち書きができるらしいので、今後に期待します。
 
 ### その他の検討アルゴリズム
 

--- a/app/app.ts
+++ b/app/app.ts
@@ -3,7 +3,7 @@ import { benchmark, getKeywords } from "@ref/bench/benchmark_common";
 import { calculateGzipedJsonSize } from "@ref/util";
 import { UniSearchError } from "@src/frontend/base";
 import { createIndex, indexToObject } from "@src/frontend/indexing";
-import { HyblidBigramInvertedIndex } from "@src/frontend/indextypes";
+import { HybridBigramInvertedIndex } from "@src/frontend/indextypes";
 import { search } from "@src/frontend/search";
 import { LinearIndex } from "@src/method/linearindex";
 import { wikipedia_ja_extracted } from "@test/wikipedia_ja_extracted";
@@ -44,7 +44,7 @@ async function runAll(wikipedia_articles: WikipediaArticle[], wikipedia_keyword:
     console.log(fuzzy_result.results);
 
     const hybrid_index_result = benchmark(
-        (arg) => createIndex(HyblidBigramInvertedIndex, arg, { key_field: "title" }),
+        (arg) => createIndex(HybridBigramInvertedIndex, arg, { key_field: "title" }),
         [wikipedia_articles],
     );
     console.log(`hybrid indexing time: ${hybrid_index_result.time} ms`);

--- a/app/bitap.ts
+++ b/app/bitap.ts
@@ -1,9 +1,0 @@
-import { wikipedia_ja_extracted } from "@test/wikipedia_ja_extracted";
-import { createIndex, LinearIndex, UniSearchError } from "@src/main";
-import { search } from "@src/main";
-
-const index = createIndex(LinearIndex, wikipedia_ja_extracted);
-if(index instanceof UniSearchError) throw index;
-
-const result = search(index, "distance:3 アンパサンド");
-console.log(result);

--- a/app/bitap.ts
+++ b/app/bitap.ts
@@ -1,0 +1,9 @@
+import { wikipedia_ja_extracted } from "@test/wikipedia_ja_extracted";
+import { createIndex, LinearIndex, UniSearchError } from "@src/main";
+import { search } from "@src/main";
+
+const index = createIndex(LinearIndex, wikipedia_ja_extracted);
+if(index instanceof UniSearchError) throw index;
+
+const result = search(index, "distance:3 アンパサンド");
+console.log(result);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "unisearch.js",
-    "version": "1.0.3",
+    "version": "1.0.4",
     "description": "Lightweight and reasonably fast full-text search engine for static sites",
     "main": "dist/unisearch.js",
     "types": "dist/unisearch.d.ts",

--- a/ref/algo.ts
+++ b/ref/algo.ts
@@ -196,7 +196,8 @@ export function createBitapKey(pattern: string): BitapKey {
     return key;
 }
 
-export function bitapSearch(key: BitapKey, maxErrors: number, text: string, pos = 0): number | null {
+export function bitapSearch(key: BitapKey, maxErrors: number, text: string, pos = 0): number[] {
+    const result: number[] = [];
     const state = Array(maxErrors + 1).fill(0);
     const matchbit = 1 << (key.length - 1);
 
@@ -212,15 +213,15 @@ export function bitapSearch(key: BitapKey, maxErrors: number, text: string, pos 
 
             replace = next_state_candidate;
             insertion = state[distance];
-            deletion = next_state;
+            deletion = (next_state << 1) | 1;
 
             state[distance] = next_state;
 
             if ((state[distance] & matchbit) !== 0) {
-                return i - key.length + 1;
+                result.push(i - key.length + 1);
             }
         }
     }
 
-    return null;
+    return result;
 }

--- a/ref/linear.ts
+++ b/ref/linear.ts
@@ -16,15 +16,6 @@ function* indicesOf(keyword: string, target: string): Generator<number> {
     }
 }
 
-function* fuzzyIndicesOf(keyword: string, target: string): Generator<number> {
-    const key = createBitapKey(keyword);
-    let pos = bitapSearch(key, 1, target);
-    while (pos !== null) {
-        yield pos;
-        pos = bitapSearch(key, 1, target, pos + keyword.length + 1);
-    }
-}
-
 export function searchLinear(query: string, index: LinearIndex): Reference[] {
     const query_normalized = normalizeText(query);
     return index.flatMap((doc, id) => {
@@ -45,7 +36,8 @@ export function searchLinear(query: string, index: LinearIndex): Reference[] {
 export function searchFuzzyLinear(query: string, index: LinearIndex): Reference[] {
     const query_normalized = normalizeText(query);
     return index.flatMap((doc, id) => {
-        const results = [...fuzzyIndicesOf(query_normalized, doc)];
+        const key = createBitapKey(query_normalized);
+        const results = bitapSearch(key, 1, doc);
         return results.length > 0
             ? {
                   id: id,

--- a/ref/sortedarray.ts
+++ b/ref/sortedarray.ts
@@ -38,7 +38,7 @@ export function searchFuzzySortedArray(query: Token, index: SortedArrayIndex): R
     const key = createBitapKey(query);
     const results = items
         .map((item, idx) => ({ idx: idx, result: bitapSearch(key, 1, item[0]) }))
-        .filter((x) => x.result !== null)
+        .filter((x) => x.result.length !== 0)
         .flatMap((x) => items[x.idx][1]);
 
     return results;

--- a/ref/test/algo.test.ts
+++ b/ref/test/algo.test.ts
@@ -87,7 +87,7 @@ test("binary search for refine: end", () =>
     ).toStrictEqual(3));
 
 const key = createBitapKey("HT");
-test("bitap search 1", () => expect(bitapSearch(key, 0, "hogeHThage")).toStrictEqual(4));
-test("bitap search 2", () => expect(bitapSearch(key, 0, "hogeHTTPShage")).toStrictEqual(4));
-test("bitap search 3", () => expect(bitapSearch(key, 0, "HTTPS")).toStrictEqual(0));
-test("bitap search 4", () => expect(bitapSearch(key, 0, "hogeHT")).toStrictEqual(4));
+test("bitap search 1", () => expect(bitapSearch(key, 0, "hogeHThage")).toStrictEqual([4]));
+test("bitap search 2", () => expect(bitapSearch(key, 0, "hogeHTTPShage")).toStrictEqual([4]));
+test("bitap search 3", () => expect(bitapSearch(key, 0, "HTTPS")).toStrictEqual([0]));
+test("bitap search 4", () => expect(bitapSearch(key, 0, "hogeHT")).toStrictEqual([4]));

--- a/src/frontend/indextypes.ts
+++ b/src/frontend/indextypes.ts
@@ -4,9 +4,9 @@ import { InvertedIndex } from "@src/method/invertedindex";
 import { LinearIndex } from "@src/method/linearindex";
 import { Ngram } from "@src/method/ngram";
 
-export const HyblidBigramInvertedIndex = Hybrid("HyblidBigramInvertedIndex", Ngram(2, InvertedIndex), InvertedIndex);
+export const HybridBigramInvertedIndex = Hybrid("HybridBigramInvertedIndex", Ngram(2, InvertedIndex), InvertedIndex);
 
 export const IndexTypes: { [key: string]: IndexClass } = {
     LinearIndex,
-    HyblidBigramInvertedIndex,
+    HybridBigramInvertedIndex,
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,7 +1,7 @@
 export { createIndex, indexToObject, createIndexFromObject } from "@src/frontend/indexing";
 export { search } from "@src/frontend/search";
 export { LinearIndex } from "@src/method/linearindex";
-export { HyblidBigramInvertedIndex } from "@src/frontend/indextypes";
+export { HybridBigramInvertedIndex } from "@src/frontend/indextypes";
 export { UniSearchError } from "@src/frontend/base";
 export type {
     UniIndex,

--- a/src/method/invertedindex.ts
+++ b/src/method/invertedindex.ts
@@ -61,7 +61,8 @@ export class InvertedIndex implements SearchIndex<InvertedIndexEntry> {
                     for (const [term, plist] of refined) {
                         const r = bitapSearch(bitapkey, env.distance || 0, splitByGrapheme(term));
                         if (r.length !== 0) {
-                            const min_dist = r.sort((a, b) => b[1] - a[1])[0][1];
+                            r.sort((a, b) => a[1] - b[1]);
+                            const min_dist = r[0][1];
                             res.push([term, plist, min_dist]);
                         }
                     }
@@ -70,7 +71,8 @@ export class InvertedIndex implements SearchIndex<InvertedIndexEntry> {
                     for (const [term, plist] of refined) {
                         const r = bitapSearch(bitapkey, env.distance || 0, splitByGrapheme(term));
                         if (r.length !== 0) {
-                            const min_dist = r.sort((a, b) => b[1] - a[1])[0][1];
+                            r.sort((a, b) => a[1] - b[1]);
+                            const min_dist = r[0][1];
                             res.push([term, plist, min_dist]);
                         }
                     }

--- a/src/util/algorithm.ts
+++ b/src/util/algorithm.ts
@@ -128,13 +128,12 @@ export function bitapSearch<T>(key: BitapKey<T>, maxErrors: number, text: string
 
             replace = next_state_candidate;
             insertion = state[distance];
-            deletion = next_state;
+            deletion = key.or(key.sl(next_state, 1), one);
 
             state[distance] = next_state;
 
             if (key.and(state[distance], matchbit) !== zero) {
                 result.push([i - key.length + 1, distance]);
-                state.fill(zero);
                 break;
             }
         }
@@ -152,13 +151,12 @@ export function bitapSearch<T>(key: BitapKey<T>, maxErrors: number, text: string
 
             replace = next_state_candidate;
             insertion = state[distance];
-            deletion = next_state;
+            deletion = key.or(key.sl(next_state, 1), one);
 
             state[distance] = next_state;
 
             if (key.and(state[distance], matchbit) !== zero) {
                 result.push([text.length - key.length, distance]);
-                state.fill(zero);
                 break;
             }
         }

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -1,6 +1,6 @@
 import { test, expect, describe } from "vitest";
 import { array_of_articles } from "@test/array_of_articles.js";
-import { LinearIndex, createIndex, search, UniSearchError, HyblidBigramInvertedIndex } from "../dist/unisearch.js";
+import { LinearIndex, createIndex, search, UniSearchError, HybridBigramInvertedIndex } from "../dist/unisearch.js";
 import { UniIndex, SearchIndex, LinearIndexEntry } from "../dist/unisearch.js";
 import { createIndexFromObject, indexToObject } from "../dist/unisearch.js";
 
@@ -527,7 +527,7 @@ describe("from: weight: search", () => {
 });
 
 describe("Hybrid bigram inverted index creation and search", () => {
-    const index = createIndex(HyblidBigramInvertedIndex, array_of_articles);
+    const index = createIndex(HybridBigramInvertedIndex, array_of_articles);
     if(index instanceof UniSearchError) throw index;
 
     const result1 = search(index, "maintainability");

--- a/test/integration.test.ts
+++ b/test/integration.test.ts
@@ -415,7 +415,7 @@ describe("not search", () => {
             {
                 id: 6,
                 key: undefined,
-                score: 0.07499711596179154,
+                score: 0.06416459750140764,
                 refs: [
                     {
                         token: "概要",


### PR DESCRIPTION
- fuzzy search bug is fixed.
  - The bitap algorithm did not correctly calculate the single-character deletion status.
  - Once a match was made, the search state was cleared entirely, resulting in fewer matches.
  - In HybridBigramInvertedIndex, the edit distance was not calculated correctly. 
- Typo in README is fixed.
- Typo of search class is fixed. Not HyblidBigramInvertedIndex, but HybridBigramInvertedIndex.